### PR TITLE
add support for cookie in move_from and move_to events

### DIFF
--- a/watcher.ini
+++ b/watcher.ini
@@ -54,4 +54,5 @@ autoadd=true
 ; $filename event-related file name
 ; $tflags event flags (textually)
 ; $nflags event flags (numerically)
+; $cookie event cookie (integer used for matching move_from and move_to events, otherwise 0)
 command=ls -l $filename

--- a/watcher.py
+++ b/watcher.py
@@ -182,7 +182,8 @@ class EventHandler(pyinotify.ProcessEvent):
         command = t.substitute(watched=self.shellquote(event.path),
                                filename=self.shellquote(event.pathname),
                                tflags=self.shellquote(event.maskname),
-                               nflags=self.shellquote(event.mask))
+                               nflags=self.shellquote(event.mask),
+                               cookie=self.shellquote(event.cookie if hasattr(event, "cookie") else 0))
         try:
             os.system(command)
         except OSError, err:


### PR DESCRIPTION
To allow matching corresponding move_from and move_to events for the same file or directory there is an cookie in the inotify event. With this change the cookie can be given as an argument to the configured command making these events much more easier to use ;-)
